### PR TITLE
Fix initial index and other features for Custom/Stack layout

### DIFF
--- a/lib/src/custom_layout.dart
+++ b/lib/src/custom_layout.dart
@@ -97,6 +97,10 @@ abstract class _CustomLayoutStateBase<T extends _SubSwiper> extends State<T>
 
     for (var i = 0; i < _animationCount!; ++i) {
       var realIndex = _currentIndex + i + _startIndex;
+
+      if (!widget.loop! && (realIndex < 0 || realIndex >= widget.itemCount!))
+        continue;
+
       realIndex = realIndex % widget.itemCount!;
       if (realIndex < 0) {
         realIndex += widget.itemCount!;

--- a/lib/src/custom_layout.dart
+++ b/lib/src/custom_layout.dart
@@ -8,6 +8,7 @@ abstract class _CustomLayoutStateBase<T extends _SubSwiper> extends State<T>
   AnimationController? _animationController;
   late int _startIndex;
   int? _animationCount;
+  int _currentIndex = 0;
 
   @override
   void initState() {
@@ -16,6 +17,9 @@ abstract class _CustomLayoutStateBase<T extends _SubSwiper> extends State<T>
         '==============\n\nwidget.itemWith must not be null when use stack layout.\n========\n',
       );
     }
+
+    // Initial index
+    _currentIndex = widget.index ?? 0;
 
     _createAnimationController();
     widget.controller!.addListener(_onController);
@@ -245,8 +249,6 @@ abstract class _CustomLayoutStateBase<T extends _SubSwiper> extends State<T>
 
     _animationController!.value = value;
   }
-
-  int _currentIndex = 0;
 }
 
 double? _getValue(List<double?> values, double animationValue, int index) {


### PR DESCRIPTION
- There was a clear bug, where the index parameter (initial index) was ignored for Stack layout. It works in the default layout.
It is fixed simply by initializing the currentIndex to the activeIndex parameter, which is already initialized to the (initial) index parameter in the parent constructors.

- There is a loop: false parameter, which does prevent swiping the loop in Stack layout. But it still visually shows the items as looping. This was fixed in the part where Custom layout creates the list of items to build, by not adding items below zero or over count, into the list. Works nicely.

And other features to Custom layout.
